### PR TITLE
use thin for longer urls and parallel requests on heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rdoc', '3.6.1'
 gem 'org-ruby', '~>0.5.0' # 0.6.0 is broken on 1.9
 gem 'creole'
 gem 'wikicloth'
+gem 'thin' # better performance on heroku + long urls possible
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,9 @@ GEM
     childprocess (0.2.4)
       ffi (~> 1.0.6)
     creole (0.4.2)
+    daemons (1.1.5)
     diff-lcs (1.1.3)
+    eventmachine (0.12.10)
     expression_parser (0.9.0)
     ffi (1.0.11)
     github-markup (0.7.0)
@@ -49,6 +51,10 @@ GEM
       rack (~> 1.3, >= 1.3.4)
       rack-protection (~> 1.1, >= 1.1.2)
       tilt (~> 1.3, >= 1.3.3)
+    thin (1.3.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     tilt (1.3.3)
     wikicloth (0.7.1)
       builder
@@ -70,4 +76,5 @@ DEPENDENCIES
   redcarpet
   rspec
   sinatra
+  thin
   wikicloth

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+#web: bundle exec thin start -p $PORT

--- a/README.markdown
+++ b/README.markdown
@@ -22,5 +22,5 @@ Then `github-preview someproject/Readme.markdown`
 
     bundle
     bundle exec rspec spec
-    bundle exec rackup
-    open http://localhost:9292
+    bundle exec thin start
+    open http://localhost:3000


### PR DESCRIPTION
- thin will use run up to 4 concurrent servers on heroku
- it can handle longer urls then webrick, enabling editing of long readme`s via the commandline (would also be possible to post them, but get is simpler)
