### PR TITLE
Fix link to underscore

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -3,7 +3,7 @@
   %head
     %title GitHub Preview
     %script{:type => "text/javascript", :src => "http://code.jquery.com/jquery-1.6.2.min.js"}
-    %script{:type => "text/javascript", :src => "http://documentcloud.github.com/underscore/underscore-min.js"}
+    %script{:type => "text/javascript", :src => "http://underscorejs.org/underscore-min.js"}
     %script{:type => "text/javascript", :src => "/scripts/app.js"}
     %link{:href => "/stylesheets/github.css", :rel => "stylesheet", :type => "text/css" }
   %body


### PR DESCRIPTION
Old link for underscore is not valid anymore, using official production build